### PR TITLE
[ARCH-282] Update DynamicDecorator configuration handling and priority assignment

### DIFF
--- a/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/DynamicDecoratorsConfig.java
+++ b/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/DynamicDecoratorsConfig.java
@@ -52,9 +52,12 @@ public class DynamicDecoratorsConfig {
 
         public void setDecorators(List<DynamicDecoratorConfig> decorators) {
             this.decorators = decorators;
+            
+            double priority = decorators.size();
 
             for (DynamicDecoratorConfig decoratorConfig : decorators) {
-                prioritiesMap.put(decoratorConfig.getDecoratorClassName(), decoratorConfig.getPriority());
+                prioritiesMap.put(decoratorConfig.getDecoratorClassName(), priority);
+                priority--;
             }
         }
 
@@ -69,9 +72,6 @@ public class DynamicDecoratorsConfig {
         @ConfigurableProperty
         String decoratorClassName;
 
-        @ConfigurableProperty(defaultValue = "1.0")
-        Double priority = 1.0;
-
         public DynamicDecoratorConfig() {
         }
 
@@ -81,14 +81,6 @@ public class DynamicDecoratorsConfig {
 
         public void setDecoratorClassName(String decoratorClassName) {
             this.decoratorClassName = decoratorClassName;
-        }
-
-        public Double getPriority() {
-            return priority;
-        }
-
-        public void setPriority(Double priority) {
-            this.priority = priority;
         }
     }
 }

--- a/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/DynamicDecoratorsConfig.java
+++ b/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/DynamicDecoratorsConfig.java
@@ -1,0 +1,94 @@
+package org.dcm4chee.conf.decorators;
+
+import org.dcm4che3.conf.core.api.ConfigurableClass;
+import org.dcm4che3.conf.core.api.ConfigurableProperty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * @author Roman K
+ */
+@ConfigurableClass
+public class DynamicDecoratorsConfig {
+
+    /**
+     * Key = Service class, e.g. org.dcm4chee.archive.store.StoreService
+     */
+    @ConfigurableProperty
+    Map<String, DynamicDecoratoredServiceConfig> decoratedServices = new TreeMap<>();
+
+    public DynamicDecoratorsConfig() {
+    }
+
+    public Map<String, DynamicDecoratoredServiceConfig> getDecoratedServices() {
+        return decoratedServices;
+    }
+
+    public void setDecoratedServices(Map<String, DynamicDecoratoredServiceConfig> decoratedServices) {
+        this.decoratedServices = decoratedServices;
+    }
+
+    @ConfigurableClass
+    public static class DynamicDecoratoredServiceConfig {
+
+        /**
+         * Key = dynamic decorator class
+         */
+        @ConfigurableProperty
+        List<DynamicDecoratorConfig> decorators = new ArrayList<>();
+
+        public DynamicDecoratoredServiceConfig() {
+        }
+
+        // populated in the setter of decorators
+        private transient Map<String, Double> prioritiesMap = new TreeMap<>();
+
+        public List<DynamicDecoratorConfig> getDecorators() {
+            return decorators;
+        }
+
+        public void setDecorators(List<DynamicDecoratorConfig> decorators) {
+            this.decorators = decorators;
+
+            for (DynamicDecoratorConfig decoratorConfig : decorators) {
+                prioritiesMap.put(decoratorConfig.getDecoratorClassName(), decoratorConfig.getPriority());
+            }
+        }
+
+        public Map<String, Double> getPrioritiesMap() {
+            return prioritiesMap;
+        }
+    }
+
+    @ConfigurableClass
+    public static class DynamicDecoratorConfig {
+
+        @ConfigurableProperty
+        String decoratorClassName;
+
+        @ConfigurableProperty(defaultValue = "1.0")
+        Double priority = 1.0;
+
+        public DynamicDecoratorConfig() {
+        }
+
+        public String getDecoratorClassName() {
+            return decoratorClassName;
+        }
+
+        public void setDecoratorClassName(String decoratorClassName) {
+            this.decoratorClassName = decoratorClassName;
+        }
+
+        public Double getPriority() {
+            return priority;
+        }
+
+        public void setPriority(Double priority) {
+            this.priority = priority;
+        }
+    }
+}

--- a/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/ServiceDecorator.java
+++ b/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/ServiceDecorator.java
@@ -1,73 +1,91 @@
 package org.dcm4chee.conf.decorators;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import javax.enterprise.inject.Instance;
-import javax.inject.Inject;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class ServiceDecorator<T> {
-	
-	@Inject
-	@ConfiguredDynamicDecorators
-	Map<String, Double> dynamicDecoratorConfiguration;
-	
-	@Inject
-	@ConfiguredDynamicDecorators
-	List<String> disabledDecorators;
-	
-	private static final Logger LOG = LoggerFactory.getLogger(ServiceDecorator.class);
-	
-	private Collection<DelegatingServiceImpl<T>> orderedDecorators = null;
-	
-	public Collection<DelegatingServiceImpl<T>> getOrderedDecorators(Instance<DelegatingServiceImpl<T>> dynamicDecoratorsForService, String clazz) {
-		if (orderedDecorators == null) {
-			initServiceDecorators(dynamicDecoratorsForService, clazz);
-		}
-		LOG.trace("Retrieved {}.", orderedDecorators);
-		return orderedDecorators;
-	}
-	
-	
-	private synchronized void initServiceDecorators(Instance<DelegatingServiceImpl<T>> dynamicDecoratorsForService, String clazz) {
-		if (orderedDecorators != null) {
-			LOG.debug("Decorators for {} were already created. Will not recreate.", clazz);
-			return;
-		}
-		LOG.debug("Creating decorators for {}.", clazz);
-		
-		Map<Double, DelegatingServiceImpl<T>> decorators = new TreeMap<Double, DelegatingServiceImpl<T>>();
-		
-		for (DelegatingServiceImpl<T> dynamicDecorator : dynamicDecoratorsForService) {
-			
-			//need to be careful - if the dynamicDecorator object has ApplicationScoped scope, then we need to go through a weld proxy class to get the annotation
-			//we would do this by doing:
-			//Class<?> clazz = dynamicDecorator.getClass().getSuperclass();
-			Class<?> decoratorClazz = dynamicDecorator.getClass();
-			if (isDecoratorEnabled(decoratorClazz)) {
-				Double priority = (Double) dynamicDecoratorConfiguration.get(decoratorClazz.getName());
-				decorators.put(priority, dynamicDecorator);
-				LOG.debug("Configuring the decorator {} with priority {}.", decoratorClazz, priority);
-			}
-		}
 
-		orderedDecorators = decorators.values();
-	}
-	
-	private boolean isDecoratorEnabled(Class<?> decoratorClazz) {
-		boolean enabled = false;
-		if (!dynamicDecoratorConfiguration.containsKey(decoratorClazz.getName())) {
-			LOG.debug("Not configuring the decorator {} because it is not in the configuration.", decoratorClazz);
-		} else if (disabledDecorators.contains(decoratorClazz.getName())) {
-			LOG.debug("Not configuring the decorator {} because it is disabled.", decoratorClazz);
-		} else {
-			enabled = true;
-		}
-		return enabled;
-	}
+//	@Inject
+//	@ConfiguredDynamicDecorators
+//	Map<String, Double> dynamicDecoratorConfiguration;
+
+    @Inject
+    @ConfiguredDynamicDecorators
+    DynamicDecoratorsConfig decoratorsConfig;
+
+
+    @Inject
+    @ConfiguredDynamicDecorators
+    List<String> disabledDecorators;
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceDecorator.class);
+
+    private Collection<DelegatingServiceImpl<T>> orderedDecorators = null;
+
+    public Collection<DelegatingServiceImpl<T>> getOrderedDecorators(Instance<DelegatingServiceImpl<T>> dynamicDecoratorsForService, String clazz) {
+        if (orderedDecorators == null) {
+            initServiceDecorators(dynamicDecoratorsForService, clazz);
+        }
+        LOG.trace("Retrieved {}.", orderedDecorators);
+        return orderedDecorators;
+    }
+
+
+    private synchronized void initServiceDecorators(Instance<DelegatingServiceImpl<T>> dynamicDecoratorsForService, String clazz) {
+        if (orderedDecorators != null) {
+            LOG.debug("Decorators for {} were already created. Will not recreate.", clazz);
+            return;
+        }
+        LOG.debug("Creating decorators for {}.", clazz);
+
+        Map<Double, DelegatingServiceImpl<T>> decorators = new TreeMap<Double, DelegatingServiceImpl<T>>();
+
+        for (DelegatingServiceImpl<T> dynamicDecorator : dynamicDecoratorsForService) {
+
+            //need to be careful - if the dynamicDecorator object has ApplicationScoped scope, then we need to go through a weld proxy class to get the annotation
+            //we would do this by doing:
+            //Class<?> clazz = dynamicDecorator.getClass().getSuperclass();
+            Class<?> decoratorClazz = dynamicDecorator.getClass();
+            if (isDecoratorEnabled(decoratorClazz, clazz)) {
+
+                Double priority = null;
+                try {
+                    priority = decoratorsConfig.getDecoratedServices().get(clazz).getPrioritiesMap().get(decoratorClazz.getName());
+                } catch (NullPointerException e) {
+                    throw new RuntimeException("Dynamic decorator configuration not found for decorator " + decoratorClazz.getName() + " of service " + clazz, e);
+                }
+                decorators.put(priority, dynamicDecorator);
+                LOG.debug("Configuring the decorator {} with priority {}.", decoratorClazz, priority);
+            }
+        }
+
+        orderedDecorators = decorators.values();
+    }
+
+    private boolean isDecoratorEnabled(Class<?> decoratorClazz, String serviceClazz) {
+        if (!decoratorsConfig.getDecoratedServices().containsKey(serviceClazz)) {
+            LOG.warn("Service class {} not defined in the dynamic decorators configuration.", serviceClazz);
+            return false;
+        }
+
+        if (!decoratorsConfig.getDecoratedServices().get(serviceClazz).getPrioritiesMap().containsKey(decoratorClazz.getName())) {
+            LOG.debug("Not configuring the decorator {} because it is not in the configuration.", decoratorClazz);
+            return false;
+        }
+
+        if (disabledDecorators.contains(decoratorClazz.getName())) {
+            LOG.debug("Not configuring the decorator {} because it is disabled.", decoratorClazz);
+            return false;
+        }
+
+        return true;
+    }
+
 }

--- a/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/ServiceDecorator.java
+++ b/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/ServiceDecorator.java
@@ -12,10 +12,6 @@ import java.util.TreeMap;
 
 public class ServiceDecorator<T> {
 
-//	@Inject
-//	@ConfiguredDynamicDecorators
-//	Map<String, Double> dynamicDecoratorConfiguration;
-
     @Inject
     @ConfiguredDynamicDecorators
     DynamicDecoratorsConfig decoratorsConfig;

--- a/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/producers/DynamicDecoratorConfigurationProducer.java
+++ b/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/producers/DynamicDecoratorConfigurationProducer.java
@@ -1,61 +1,45 @@
 package org.dcm4chee.conf.decorators.producers;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.enterprise.inject.Produces;
-
+import org.dcm4che3.conf.core.DefaultBeanVitalizer;
 import org.dcm4che3.conf.core.api.ConfigurationException;
 import org.dcm4che3.conf.core.storage.SingleJsonFileConfigurationStorage;
 import org.dcm4chee.conf.decorators.ConfiguredDynamicDecorators;
+import org.dcm4chee.conf.decorators.DynamicDecoratorsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.enterprise.inject.Produces;
+import java.util.Map;
+
 public class DynamicDecoratorConfigurationProducer {
-    private static final String DECORATOR_CLASS_NAME = "decoratorClassName";
-    private static final String PRIORITY = "priority";
-    private static final double DEFAULT_PRIORITY = 1.0;
+
     // TODO: make sure deterministic ordering if priority is the same
 
     private static final Logger LOG = LoggerFactory
             .getLogger(DynamicDecoratorConfigurationProducer.class);
 
+    @SuppressWarnings("unchecked")
     @Produces
     @ConfiguredDynamicDecorators
-    public Map<String, Double> getDynamicDecoratorConfiguration() throws ConfigurationException {
+    public DynamicDecoratorsConfig getDynamicDecoratorConfiguration() throws ConfigurationException {
         String path = getPath();
         SingleJsonFileConfigurationStorage storage = new SingleJsonFileConfigurationStorage(path);
-        List<Map<String, Object>> config = (List<Map<String, Object>>) storage
-                .getConfigurationNode("dynamicDecorators", null);
 
-        Map<String, Double> configuredDynamicDecorators = new HashMap<String, Double>();
-        if (config != null) {
-            for (Map<String, Object> object : config) {
-                if (object.containsKey(DECORATOR_CLASS_NAME)) {
-                    String decoratorClassName = (String) object.get(DECORATOR_CLASS_NAME);
-                    double priority = getPriority(object);
-                    LOG.debug("Found dynamic decorator {} in configuration with priority {}.", decoratorClassName, priority);
-                    configuredDynamicDecorators.put(decoratorClassName, priority);
-                }
-            }
+        DynamicDecoratorsConfig dynamicDecorators = new DefaultBeanVitalizer().newConfiguredInstance((Map<String, Object>) storage
+                .getConfigurationNode("/", null), DynamicDecoratorsConfig.class);
+
+        for (Map.Entry<String, DynamicDecoratorsConfig.DynamicDecoratoredServiceConfig> entry : dynamicDecorators.getDecoratedServices().entrySet()) {
+            LOG.debug("Dynamic decorators for service {}:",entry.getKey());
+            for (DynamicDecoratorsConfig.DynamicDecoratorConfig dynamicDecoratorConfig : entry.getValue().getDecorators())
+                LOG.debug("Found dynamic decorator {} in configuration with priority {}.", dynamicDecoratorConfig.getDecoratorClassName(), dynamicDecoratorConfig.getPriority());
         }
 
-        return configuredDynamicDecorators;
+        return dynamicDecorators;
     }
 
     private String getPath() {
         return System.getProperty("org.dcm4che.conf.dynamic.decorator.config",
-                        "../standalone/configuration/dcm4chee-arc/dynamic-decorators.json");
+                "../standalone/configuration/dcm4chee-arc/dynamic-decorators.json");
     }
 
-    private double getPriority(Map<String, Object> map) {
-        double priority;
-        if (map.containsKey(PRIORITY)) {
-            priority = (double) map.get(PRIORITY);
-        } else {
-            priority = DEFAULT_PRIORITY;
-        }
-        return priority;
-    }
 }

--- a/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/producers/DynamicDecoratorConfigurationProducer.java
+++ b/dcm4chee-conf-decorators/src/main/java/org/dcm4chee/conf/decorators/producers/DynamicDecoratorConfigurationProducer.java
@@ -13,8 +13,6 @@ import java.util.Map;
 
 public class DynamicDecoratorConfigurationProducer {
 
-    // TODO: make sure deterministic ordering if priority is the same
-
     private static final Logger LOG = LoggerFactory
             .getLogger(DynamicDecoratorConfigurationProducer.class);
 
@@ -28,10 +26,12 @@ public class DynamicDecoratorConfigurationProducer {
         DynamicDecoratorsConfig dynamicDecorators = new DefaultBeanVitalizer().newConfiguredInstance((Map<String, Object>) storage
                 .getConfigurationNode("/", null), DynamicDecoratorsConfig.class);
 
-        for (Map.Entry<String, DynamicDecoratorsConfig.DynamicDecoratoredServiceConfig> entry : dynamicDecorators.getDecoratedServices().entrySet()) {
-            LOG.debug("Dynamic decorators for service {}:",entry.getKey());
-            for (DynamicDecoratorsConfig.DynamicDecoratorConfig dynamicDecoratorConfig : entry.getValue().getDecorators())
-                LOG.debug("Found dynamic decorator {} in configuration with priority {}.", dynamicDecoratorConfig.getDecoratorClassName(), dynamicDecoratorConfig.getPriority());
+        if (LOG.isDebugEnabled()) {
+	        for (Map.Entry<String, DynamicDecoratorsConfig.DynamicDecoratoredServiceConfig> entry : dynamicDecorators.getDecoratedServices().entrySet()) {
+	            LOG.debug("Dynamic decorators for service {}:",entry.getKey());
+	            for (DynamicDecoratorsConfig.DynamicDecoratorConfig dynamicDecoratorConfig : entry.getValue().getDecorators())
+	                LOG.debug("Found dynamic decorator {} in configuration.", dynamicDecoratorConfig.getDecoratorClassName());
+	        }
         }
 
         return dynamicDecorators;


### PR DESCRIPTION
Pulling in changes from Roman which loads the decorators by service, and also introduces proper configuration handling for the dynamic decoration.

Pulling in changes from Greg which assigns priority to the dynamic decorators based off of their order in the file (similar to how the beans.xml loading for decorators/interceptors works).
